### PR TITLE
Implemented double-checking params mechanism

### DIFF
--- a/astroabc/abc_class.py
+++ b/astroabc/abc_class.py
@@ -5,19 +5,19 @@
 import numpy as np
 import scipy.stats
 import sys
-from sklearn.covariance import GraphLassoCV, ledoit_wolf
+from sklearn.covariance import GraphicalLassoCV, ledoit_wolf
 #import os
 #sys.path.append(os.getcwd())
 
 import six
 
-from .myutils import *
-from .tolerance import *
-from .variance import *
-from .priors import *
-from .model import *
-from .io_utils import *
-from .setup_mpi_mp import *
+from myutils import *
+from tolerance import *
+from variance import *
+from priors import *
+from model import *
+from io_utils import *
+from setup_mpi_mp import *
 
 try:
         from mpi4py import MPI

--- a/astroabc/setup_mpi_mp.py
+++ b/astroabc/setup_mpi_mp.py
@@ -1,6 +1,6 @@
 
 
-from astroabc.mpi_pool import MpiPool
+from mpi_pool import MpiPool
 import multiprocessing as mp
 import numpy as np
 import types


### PR DESCRIPTION
Sometimes it is important to ensure that parameters generated in step > 0 match previously declared range. For example: parameter declared as "unified" with range [0, 1] is set to 0.001 in step 0. During next step we use variance to generate better value for this parameter and we get -0.001.  Negative value that we didn't expect breaks our simulation. Double-checking mechanism prevents this.